### PR TITLE
Add Controller Tester to Testing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@
 ## 🧪 Testing
 - [LizardByte/Gamepad-Tester](https://app.lizardbyte.dev/gamepad-tester) - Official LizardByte gamepad tester.
 - [HardwareTester/GamepadTester](https://hardwaretester.com/gamepad) - This tool displays the current state of your gamepads, inputs, joysticks, and anything else that can be reported by the HTML5 Gamepad Api.
+- [Controller Tester](https://controllertester.co/) - Free browser-based gamepad and controller tester for buttons, sticks, triggers, and vibration, with a dedicated stick-drift test.
 
 ## 📓 Guides
 - [LizardByte docs](https://docs.lizardbyte.dev/projects/sunshine) - Official documentation for Sunshine.


### PR DESCRIPTION
## Summary
Adds [Controller Tester](https://controllertester.co/) to the **🧪 Testing** section, alongside the existing LizardByte Gamepad-Tester and HardwareTester entries.

It's a free, browser-based gamepad/controller tester (buttons, sticks, triggers, vibration) with a dedicated stick-drift test — useful for verifying a controller before/while streaming with Sunshine. Same category as the two testing tools already listed.

## Checklist
- [x] Entry placed in the relevant section (Testing) and follows the existing `- [Name](url) - description.` format
- [x] Link is live over HTTPS (HTTP 200) and not a duplicate of an existing entry
- [x] Free to use, no signup